### PR TITLE
Allow for shifts greater than one cycle in FFAGroupShiftAdd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,23 +4,7 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/dictionaries
-
-# Sensitive or high-churn files:
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.xml
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-
-# Gradle:
-.idea/**/gradle.xml
-.idea/**/libraries
+.idea/
 
 # CMake
 cmake-build-debug/
@@ -59,11 +43,7 @@ fabric.properties
 
 # *.iml
 # modules.xml
-# .idea/misc.xml
 # *.ipr
-
-# Sonarlint plugin
-.idea/sonarlint
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/FFA/FFA.py
+++ b/FFA/FFA.py
@@ -101,6 +101,9 @@ def FFAGroupShiftAdd(group0,Arow,Brow,Bshft):
     sizes = np.array([Arow.size, Brow.size, Bshft.size])
     assert (sizes == nRowGroup).all() , 'Number of rows in group must agree with butterfly output'
 
+    # Adjust for greater than one cycle wrapping
+    Bshft = Bshft % nColGroup
+
     # Grow group by the maximum shift value
     maxShft = max(Bshft)
     group0 = np.hstack( [group0 , group0[:,: maxShft]] )


### PR DESCRIPTION
Thanks for the pull. I made another change that might be useful, to allow for shifts greater than one cycle in FFAGroupShiftAdd. This removes the restriction that the number of rows in the input array must be >= the number of columns/2, which is useful for long time series data. 