### PR TITLE
np.int and np.float are deprecated

### DIFF
--- a/FFA/BLS_cy.pyx
+++ b/FFA/BLS_cy.pyx
@@ -2,7 +2,7 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-DTYPE  = np.float
+DTYPE  = float
 ctypedef np.float_t DTYPE_t
 
 cdef extern from "math.h":

--- a/FFA/FBLS_cy.pyx
+++ b/FFA/FBLS_cy.pyx
@@ -9,10 +9,10 @@ import FFA_cy as FFA
 cimport cython
 cimport numpy as np
 
-DTYPE  = np.float
+DTYPE  = float
 ctypedef np.float_t DTYPE_t
 
-I_DTYPE = np.int
+I_DTYPE = int
 ctypedef np.int_t I_DTYPE_t
 
 #cython: cdivision=True


### PR DESCRIPTION
In recent numpy (as of NumPy 1.20) `np.int` and `np.float` are deprecated and later removed.  You can use the python types `int` and `float` or the numpy types with explicit size such as `np.int32`.


```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. 
To avoid this error in existing code, use `int` by itself. 
Doing this will not modify any behavior and is safe. 
When replacing `np.int`, you may wish to use e.g. 
`np.int64` or `np.int32` to specify the precision. 
If you wish to review your current use, check the release
 note link for additional information.
The aliases was originally deprecated in NumPy 1.20; f
or more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
```