### PR TITLE
Fixed type conversion strictness in current cython.  Bumped version.

### DIFF
--- a/FFA/FFA_cy.pyx
+++ b/FFA/FFA_cy.pyx
@@ -126,7 +126,7 @@ def FFAShiftAdd(cnp.ndarray[cnp.float32_t, ndim=2] XW0,
 
     nRow = XW0.shape[0]
     nCol = XW0.shape[1]
-    nRowGroup = 2**stage
+    nRowGroup = int(2**stage)
     nGroup    = int(nRow/nRowGroup)
     XW =  np.zeros((nRow,nCol),dtype=np.float32)
     for iGroup in range(nGroup):

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setup(
         'FFA': ['sample_data/*']
     },
     requires=['numpy', 'cython'],
-    version='0.0.1',
+    version='0.0.2',
 )


### PR DESCRIPTION
Used casting to fix cython error message:

```
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          cdef int nRow,nCol,nGroup,nRowGroup,iGroup,start,stop
          cdef cnp.ndarray[cnp.float32_t, ndim=2] XW

          nRow = XW0.shape[0]
          nCol = XW0.shape[1]
          nRowGroup = 2**stage
                       ^
      ------------------------------------------------------------

      FFA/FFA_cy.pyx:129:17: Cannot assign type 'double' to 'int'
```
